### PR TITLE
refactor: split get world ids out into two functions

### DIFF
--- a/tests/cloud_functions/test_create_questionnaire_case_tasks.py
+++ b/tests/cloud_functions/test_create_questionnaire_case_tasks.py
@@ -18,20 +18,21 @@ from cloud_functions.create_questionnaire_case_tasks import (
     get_questionnaire_case_model_list,
     get_world_ids,
     validate_request,
-    append_uacs_to_retained_case
+    append_uacs_to_retained_case,
+    get_cases_with_valid_world_ids
 )
 from models.totalmobile_job_model import TotalmobileJobModel
 
 
 def test_create_task_name_returns_correct_name_when_called():
-    questionnaire_case_model = QuestionnaireCaseModel(serial_number = "90001")
+    questionnaire_case_model = QuestionnaireCaseModel(serial_number="90001")
     model = TotalmobileJobModel("OPN2101A", "world", questionnaire_case_model.to_dict())
 
     assert create_task_name(model).startswith("OPN2101A-90001-")
 
 
 def test_create_task_name_returns_unique_name_each_time_when_passed_the_same_model():
-    questionnaire_case_model = QuestionnaireCaseModel(serial_number = "90001")
+    questionnaire_case_model = QuestionnaireCaseModel(serial_number="90001")
     model = TotalmobileJobModel("OPN2101A", "world", questionnaire_case_model.to_dict())
 
     assert create_task_name(model) != create_task_name(model)
@@ -95,13 +96,13 @@ def test_get_case_data_returns_the_case_data_supplied_by_the_rest_api_client(
     result = get_questionnaire_case_model_list(questionnaire_name, config)
 
     # assert
-    assert result[0].serial_number == "10010" 
+    assert result[0].serial_number == "10010"
     assert result[0].outcome_code == "110"
 
-    assert result[1].serial_number == "10020" 
+    assert result[1].serial_number == "10020"
     assert result[1].outcome_code == "210"
 
-    assert result[2].serial_number == "10030" 
+    assert result[2].serial_number == "10030"
     assert result[2].outcome_code == "310"
 
 
@@ -110,9 +111,9 @@ def test_map_totalmobile_job_models_maps_the_correct_list_of_models():
     questionnaire_name = "OPN2101A"
 
     case_data = [
-        QuestionnaireCaseModel(serial_number = "10010", outcome_code = "110"),
-        QuestionnaireCaseModel(serial_number = "10020", outcome_code = "120"),
-        QuestionnaireCaseModel(serial_number = "10030", outcome_code = "130")
+        QuestionnaireCaseModel(serial_number="10010", outcome_code="110"),
+        QuestionnaireCaseModel(serial_number="10020", outcome_code="120"),
+        QuestionnaireCaseModel(serial_number="10030", outcome_code="130")
     ]
 
     world_ids = [
@@ -127,13 +128,31 @@ def test_map_totalmobile_job_models_maps_the_correct_list_of_models():
     # assert
     assert result == [
         TotalmobileJobModel(
-            "OPN2101A", "3fa85f64-5717-4562-b3fc-2c963f66afa6", case={'qiD.Serial_Number': '10010', 'dataModelName': '', 'qDataBag.TLA': '', 'qDataBag.Wave': '', 'qDataBag.Prem1': '', 'qDataBag.Prem2': '', 'qDataBag.Prem3': '', 'qDataBag.District': '', 'qDataBag.PostTown': '', 'qDataBag.PostCode': '', 'qDataBag.TelNo': '', 'qDataBag.TelNo2': '', 'telNoAppt': '', 'hOut': '110', 'qDataBag.UPRN_Latitude': '', 'qDataBag.UPRN_Longitude': '', 'qDataBag.Priority': '', 'qDataBag.FieldRegion': '', 'qDataBag.FieldTeam': '', 'qDataBag.WaveComDTE': '', 'uac_chunks': {'uac1': '', 'uac2': '', 'uac3': ''}}
+            "OPN2101A", "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            case={'qiD.Serial_Number': '10010', 'dataModelName': '', 'qDataBag.TLA': '', 'qDataBag.Wave': '',
+                  'qDataBag.Prem1': '', 'qDataBag.Prem2': '', 'qDataBag.Prem3': '', 'qDataBag.District': '',
+                  'qDataBag.PostTown': '', 'qDataBag.PostCode': '', 'qDataBag.TelNo': '', 'qDataBag.TelNo2': '',
+                  'telNoAppt': '', 'hOut': '110', 'qDataBag.UPRN_Latitude': '', 'qDataBag.UPRN_Longitude': '',
+                  'qDataBag.Priority': '', 'qDataBag.FieldRegion': '', 'qDataBag.FieldTeam': '',
+                  'qDataBag.WaveComDTE': '', 'uac_chunks': {'uac1': '', 'uac2': '', 'uac3': ''}}
         ),
         TotalmobileJobModel(
-            "OPN2101A", "3fa85f64-5717-4562-b3fc-2c963f66afa7", case={'qiD.Serial_Number': '10020', 'dataModelName': '', 'qDataBag.TLA': '', 'qDataBag.Wave': '', 'qDataBag.Prem1': '', 'qDataBag.Prem2': '', 'qDataBag.Prem3': '', 'qDataBag.District': '', 'qDataBag.PostTown': '', 'qDataBag.PostCode': '', 'qDataBag.TelNo': '', 'qDataBag.TelNo2': '', 'telNoAppt': '', 'hOut': '120', 'qDataBag.UPRN_Latitude': '', 'qDataBag.UPRN_Longitude': '', 'qDataBag.Priority': '', 'qDataBag.FieldRegion': '', 'qDataBag.FieldTeam': '', 'qDataBag.WaveComDTE': '', 'uac_chunks': {'uac1': '', 'uac2': '', 'uac3': ''}}
+            "OPN2101A", "3fa85f64-5717-4562-b3fc-2c963f66afa7",
+            case={'qiD.Serial_Number': '10020', 'dataModelName': '', 'qDataBag.TLA': '', 'qDataBag.Wave': '',
+                  'qDataBag.Prem1': '', 'qDataBag.Prem2': '', 'qDataBag.Prem3': '', 'qDataBag.District': '',
+                  'qDataBag.PostTown': '', 'qDataBag.PostCode': '', 'qDataBag.TelNo': '', 'qDataBag.TelNo2': '',
+                  'telNoAppt': '', 'hOut': '120', 'qDataBag.UPRN_Latitude': '', 'qDataBag.UPRN_Longitude': '',
+                  'qDataBag.Priority': '', 'qDataBag.FieldRegion': '', 'qDataBag.FieldTeam': '',
+                  'qDataBag.WaveComDTE': '', 'uac_chunks': {'uac1': '', 'uac2': '', 'uac3': ''}}
         ),
         TotalmobileJobModel(
-            "OPN2101A", "3fa85f64-5717-4562-b3fc-2c963f66afa9", case={'qiD.Serial_Number': '10030', 'dataModelName': '', 'qDataBag.TLA': '', 'qDataBag.Wave': '', 'qDataBag.Prem1': '', 'qDataBag.Prem2': '', 'qDataBag.Prem3': '', 'qDataBag.District': '', 'qDataBag.PostTown': '', 'qDataBag.PostCode': '', 'qDataBag.TelNo': '', 'qDataBag.TelNo2': '', 'telNoAppt': '', 'hOut': '130', 'qDataBag.UPRN_Latitude': '', 'qDataBag.UPRN_Longitude': '', 'qDataBag.Priority': '', 'qDataBag.FieldRegion': '', 'qDataBag.FieldTeam': '', 'qDataBag.WaveComDTE': '', 'uac_chunks': {'uac1': '', 'uac2': '', 'uac3': ''}}
+            "OPN2101A", "3fa85f64-5717-4562-b3fc-2c963f66afa9",
+            case={'qiD.Serial_Number': '10030', 'dataModelName': '', 'qDataBag.TLA': '', 'qDataBag.Wave': '',
+                  'qDataBag.Prem1': '', 'qDataBag.Prem2': '', 'qDataBag.Prem3': '', 'qDataBag.District': '',
+                  'qDataBag.PostTown': '', 'qDataBag.PostCode': '', 'qDataBag.TelNo': '', 'qDataBag.TelNo2': '',
+                  'telNoAppt': '', 'hOut': '130', 'qDataBag.UPRN_Latitude': '', 'qDataBag.UPRN_Longitude': '',
+                  'qDataBag.Priority': '', 'qDataBag.FieldRegion': '', 'qDataBag.FieldTeam': '',
+                  'qDataBag.WaveComDTE': '', 'uac_chunks': {'uac1': '', 'uac2': '', 'uac3': ''}}
         ),
     ]
 
@@ -143,121 +162,121 @@ def test_filter_cases_returns_cases_only_where_criteria_is_met():
     cases = [
         # should return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "1",
-            outcome_code= "310"  
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="1",
+            outcome_code="310"
         ),
         # should not return
         QuestionnaireCaseModel(
-            telephone_number_1 = "123435",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "1",
-            outcome_code= "310"  
-        ),      
+            telephone_number_1="123435",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="1",
+            outcome_code="310"
+        ),
         # should not return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "123435",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "1",
-            outcome_code= "310"  
-        ),      
+            telephone_number_1="",
+            telephone_number_2="123435",
+            appointment_telephone_number="",
+            wave="1",
+            priority="1",
+            outcome_code="310"
+        ),
         # should not return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "123435",          
-            wave = "1",
-            priority = "1",
-            outcome_code= "310"  
-        ),    
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="123435",
+            wave="1",
+            priority="1",
+            outcome_code="310"
+        ),
         # should not return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "2",
-            priority = "1",
-            outcome_code= "310"  
-        ),       
-         # should not return
-        QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "6",
-            outcome_code= "310"  
-        ),                       
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="2",
+            priority="1",
+            outcome_code="310"
+        ),
         # should not return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "1",
-            outcome_code= "410"  
-        ),       
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="6",
+            outcome_code="310"
+        ),
+        # should not return
+        QuestionnaireCaseModel(
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="1",
+            outcome_code="410"
+        ),
         # should return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "1",
-            outcome_code= "0"  
-        ),      
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="1",
+            outcome_code="0"
+        ),
         # should return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "2",
-            outcome_code= "0"  
-        ),   
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="2",
+            outcome_code="0"
+        ),
         # should return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "3",
-            outcome_code= "0"  
-        ),  
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="3",
+            outcome_code="0"
+        ),
         # should return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "4",
-            outcome_code= "0"  
-        ),  
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="4",
+            outcome_code="0"
+        ),
         # should return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "5",
-            outcome_code= "0"  
-        ),     
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="5",
+            outcome_code="0"
+        ),
         # should return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "5",
-            outcome_code= ""  
-        )                                                
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="5",
+            outcome_code=""
+        )
     ]
     # act
 
@@ -269,62 +288,62 @@ def test_filter_cases_returns_cases_only_where_criteria_is_met():
     assert result == [
         # should return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "1",
-            outcome_code= "310"  
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="1",
+            outcome_code="310"
         ),
-   # should return
+        # should return
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "1",
-            outcome_code= "0"  
-        ),      
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="1",
+            outcome_code="0"
+        ),
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "2",
-            outcome_code= "0"  
-        ),   
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="2",
+            outcome_code="0"
+        ),
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "3",
-            outcome_code= "0"  
-        ),  
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="3",
+            outcome_code="0"
+        ),
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "4",
-            outcome_code= "0"  
-        ),  
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="4",
+            outcome_code="0"
+        ),
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "5",
-            outcome_code= "0"  
-        ),     
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="5",
+            outcome_code="0"
+        ),
         QuestionnaireCaseModel(
-            telephone_number_1 = "",
-            telephone_number_2 = "",
-            appointment_telephone_number = "",          
-            wave = "1",
-            priority = "5",
-            outcome_code= ""  
-        )  
+            telephone_number_1="",
+            telephone_number_2="",
+            appointment_telephone_number="",
+            wave="1",
+            priority="5",
+            outcome_code=""
+        )
     ]
 
 
@@ -358,9 +377,9 @@ def test_create_case_tasks_for_questionnaire(
     mock_request = flask.Request.from_values(json={"questionnaire": "LMS2101_AA1"})
     config = config_helper.get_default_config()
     mock_get_questionnaire_case_model_list.return_value = [
-        QuestionnaireCaseModel(serial_number = "10010"), 
-        QuestionnaireCaseModel(serial_number = "10012")]
-    mock_filter_cases.return_value = [QuestionnaireCaseModel(serial_number = "10010")]
+        QuestionnaireCaseModel(serial_number="10010"),
+        QuestionnaireCaseModel(serial_number="10012")]
+    mock_filter_cases.return_value = [QuestionnaireCaseModel(serial_number="10010")]
     mock_get_uacs_by_case_id.return_value = {
         "10010": {
             "instrument_name": "LMS2101_AA1",
@@ -374,21 +393,21 @@ def test_create_case_tasks_for_questionnaire(
         }
     }
     mock_append_uacs_to_retained_case.return_value = [QuestionnaireCaseModel(
-                serial_number = "10010",
-                uac_chunks = UacChunks(uac1 = "8176", uac2 = "4726", uac3 = "3991"))]
-    
-    mock_get_world_ids.return_value = "1", [QuestionnaireCaseModel(serial_number = "10010")]
+        serial_number="10010",
+        uac_chunks=UacChunks(uac1="8176", uac2="4726", uac3="3991"))]
+
+    mock_get_world_ids.return_value = "1", [QuestionnaireCaseModel(serial_number="10010")]
     # act
     result = create_questionnaire_case_tasks(mock_request, config)
 
     # assert
     mock_get_questionnaire_case_model_list.assert_called_with("LMS2101_AA1", config)
     mock_get_world_ids.assert_called_with(config, [QuestionnaireCaseModel(
-                serial_number = "10010",
-                uac_chunks = UacChunks(uac1 = "8176", uac2 = "4726", uac3 = "3991"))])
+        serial_number="10010",
+        uac_chunks=UacChunks(uac1="8176", uac2="4726", uac3="3991"))])
     mock_filter_cases.assert_called_with([
-        QuestionnaireCaseModel(serial_number = "10010"), 
-        QuestionnaireCaseModel(serial_number = "10012")])
+        QuestionnaireCaseModel(serial_number="10010"),
+        QuestionnaireCaseModel(serial_number="10012")])
     mock_run_async_tasks.assert_called_once()
     kwargs = mock_run_async_tasks.call_args.kwargs
     assert kwargs['cloud_function'] == "totalmobile_job_cloud_function"
@@ -398,7 +417,16 @@ def test_create_case_tasks_for_questionnaire(
     assert task[0][0:3] == "LMS"
     print(json.loads(task[1]))
 
-    assert json.loads(task[1]) == {'questionnaire': 'LMS2101_AA1', 'world_id': '1', 'case': {'qiD.Serial_Number': '10010', 'dataModelName': '', 'qDataBag.TLA': '', 'qDataBag.Wave': '', 'qDataBag.Prem1': '', 'qDataBag.Prem2': '', 'qDataBag.Prem3': '', 'qDataBag.District': '', 'qDataBag.PostTown': '', 'qDataBag.PostCode': '', 'qDataBag.TelNo': '', 'qDataBag.TelNo2': '', 'telNoAppt': '', 'hOut': '', 'qDataBag.UPRN_Latitude': '', 'qDataBag.UPRN_Longitude': '', 'qDataBag.Priority': '', 'qDataBag.FieldRegion': '', 'qDataBag.FieldTeam': '', 'qDataBag.WaveComDTE': '', 'uac_chunks': {'uac1': '', 'uac2': '', 'uac3': ''}}}
+    assert json.loads(task[1]) == {'questionnaire': 'LMS2101_AA1', 'world_id': '1',
+                                   'case': {'qiD.Serial_Number': '10010', 'dataModelName': '', 'qDataBag.TLA': '',
+                                            'qDataBag.Wave': '', 'qDataBag.Prem1': '', 'qDataBag.Prem2': '',
+                                            'qDataBag.Prem3': '', 'qDataBag.District': '', 'qDataBag.PostTown': '',
+                                            'qDataBag.PostCode': '', 'qDataBag.TelNo': '', 'qDataBag.TelNo2': '',
+                                            'telNoAppt': '', 'hOut': '', 'qDataBag.UPRN_Latitude': '',
+                                            'qDataBag.UPRN_Longitude': '', 'qDataBag.Priority': '',
+                                            'qDataBag.FieldRegion': '', 'qDataBag.FieldTeam': '',
+                                            'qDataBag.WaveComDTE': '',
+                                            'uac_chunks': {'uac1': '', 'uac2': '', 'uac3': ''}}}
     assert result == "Done"
 
 
@@ -432,7 +460,7 @@ def test_create_questionnaire_case_tasks_when_no_cases_after_filtering(
     # arrange
     mock_request = flask.Request.from_values(json={"questionnaire": "LMS2101_AA1"})
     config = config_helper.get_default_config()
-    mock_get_questionnaire_case_model_list.return_value = [QuestionnaireCaseModel(serial_number = "10010")]
+    mock_get_questionnaire_case_model_list.return_value = [QuestionnaireCaseModel(serial_number="10010")]
     mock_filter_cases.return_value = []
     # act
     result = create_questionnaire_case_tasks(mock_request, config)
@@ -465,9 +493,10 @@ def test_get_wave_from_questionnaire_name_errors_for_non_lms_questionnaire(
     # arrange
     config = config_helper.get_default_config()
     mock_request = flask.Request.from_values(json={"questionnaire": "OPN2101A"})
-    mock_get_questionnaire_case_model_list.return_value = [QuestionnaireCaseModel(serial_number = "10010"), QuestionnaireCaseModel(serial_number = "10012")]
+    mock_get_questionnaire_case_model_list.return_value = [QuestionnaireCaseModel(serial_number="10010"),
+                                                           QuestionnaireCaseModel(serial_number="10012")]
     mock_get_world_ids.return_value = "1"
-    mock_filter_cases.return_value = [QuestionnaireCaseModel(serial_number = "10010")]
+    mock_filter_cases.return_value = [QuestionnaireCaseModel(serial_number="10010")]
 
     # act
     with pytest.raises(Exception) as err:
@@ -489,14 +518,8 @@ def test_get_wave_from_questionnaire_name_with_invalid_format_raises_error():
 
 
 @mock.patch.object(OptimiseClient, "get_worlds")
-def test_get_world_ids_correctly_maps_a_case_field_region_to_a_world_id(_mock_optimise_client):
-    # arrange
+def test_get_world_ids_returns_a_dictionary_with_region_and_world_id_as_a_key_value_pair(_mock_optimise_client):
     config = config_helper.get_default_config()
-
-    filtered_cases = [QuestionnaireCaseModel(field_region = "Region 1"),
-                      QuestionnaireCaseModel(field_region = "Region 2"),
-                      QuestionnaireCaseModel(field_region = "Region 4")]    
-
     _mock_optimise_client.return_value = [
         {
             "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
@@ -505,148 +528,70 @@ def test_get_world_ids_correctly_maps_a_case_field_region_to_a_world_id(_mock_op
             },
             "type": "foo"
         },
-        {
-            "id": "3fa85f64-5717-4562-b3fc-2c963f66afa7",
-            "identity": {
-                "reference": "Region 2"
-            },
-            "type": "foo"
-        },
-        {
-            "id": "3fa85f64-5717-4562-b3fc-2c963f66afa8",
-            "identity": {
-                "reference": "Region 3"
-            },
-            "type": "foo"
-        },
-        {
-            "id": "3fa85f64-5717-4562-b3fc-2c963f66afa9",
-            "identity": {
-                "reference": "Region 4"
-            },
-            "type": "foo"
-        },
     ]
 
-    world_ids, new_filtered_cases = get_world_ids(config, filtered_cases)
-
-    # assert
-    assert world_ids == [
-        "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-        "3fa85f64-5717-4562-b3fc-2c963f66afa7",
-        "3fa85f64-5717-4562-b3fc-2c963f66afa9",
-    ]
-
-    assert new_filtered_cases == [
-        QuestionnaireCaseModel(field_region = "Region 1"),
-        QuestionnaireCaseModel(field_region = "Region 2"),
-        QuestionnaireCaseModel(field_region = "Region 4")
-    ]
+    assert get_world_ids(config) == {
+        "Region 1": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    }
 
 
 @mock.patch.object(OptimiseClient, "get_worlds")
-def test_get_world_ids_logs_a_console_error_when_given_an_unknown_world(_mock_optimise_client, caplog):
-    # arrange
-    config = config_helper.get_default_config()
+def test_get_cases_with_valid_world_ids_logs_a_console_error_when_given_an_unknown_region(_mock_optimise_client,
+                                                                                          caplog):
+    filtered_cases = [QuestionnaireCaseModel(field_region="Risca")]
+    world_ids = {
+        "Region 1": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    }
 
-    filtered_cases = [QuestionnaireCaseModel(field_region = "Risca")]    
+    get_cases_with_valid_world_ids(filtered_cases, world_ids)
 
-    _mock_optimise_client.return_value = [
-        {
-            "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "identity": {
-                "reference": "Region 1"
-            },
-            "type": "foo"
-        },
-    ]
-
-    # act 
-    get_world_ids(config, filtered_cases)
-
-    # assert
     assert ('root', logging.WARNING, 'Unsupported world: Risca') in caplog.record_tuples
 
 
 @mock.patch.object(OptimiseClient, "get_worlds")
-def test_get_world_ids_logs_a_console_error_and_returns_data_when_given_an_unknown_world_and_a_known_world(
+def test_get_cases_with_valid_world_ids_logs_a_console_error_and_returns_data_when_given_an_unknown_world_and_a_known_world(
         _mock_optimise_client, caplog):
-    # arrange
-    config = config_helper.get_default_config()
+    filtered_cases = [QuestionnaireCaseModel(field_region="Risca"),
+                      QuestionnaireCaseModel(field_region="Region 1")]
+    world_ids = {
+        "Region 1": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    }
 
-    filtered_cases = [QuestionnaireCaseModel(field_region = "Risca"),
-                      QuestionnaireCaseModel(field_region = "Region 1")]    
+    cases_with_valid_world_ids = get_cases_with_valid_world_ids(filtered_cases, world_ids)
 
-    _mock_optimise_client.return_value = [
-        {
-            "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "identity": {
-                "reference": "Region 1"
-            },
-            "type": "foo"
-        },
-    ]
-
-    # act 
-    world_ids, new_filtered_cases = get_world_ids(config, filtered_cases)
-
-    # assert
-    assert len(world_ids) == len(new_filtered_cases)
-    assert world_ids == ["3fa85f64-5717-4562-b3fc-2c963f66afa6"]
-    assert new_filtered_cases == [QuestionnaireCaseModel(field_region = "Region 1")]
+    assert len(cases_with_valid_world_ids) == 1
+    assert cases_with_valid_world_ids == [QuestionnaireCaseModel(field_region = "Region 1")]
     assert ('root', logging.WARNING, 'Unsupported world: Risca') in caplog.record_tuples
 
 
 @mock.patch.object(OptimiseClient, "get_worlds")
-def test_get_world_ids_logs_a_console_error_when_field_region_is_missing(_mock_optimise_client, caplog):
-    # arrange
-    config = config_helper.get_default_config()
+def test_get_cases_with_valid_world_ids_logs_a_console_error_when_field_region_is_an_empty_value(_mock_optimise_client, caplog):
+    filtered_cases = [QuestionnaireCaseModel(field_region="")]
+    world_ids = {
+        "Region 1": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    }
 
-    filtered_cases = [QuestionnaireCaseModel(field_region = "")]    
+    get_cases_with_valid_world_ids(filtered_cases, world_ids)
 
-    _mock_optimise_client.return_value = [
-        {
-            "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "identity": {
-                "reference": "Region 1"
-            },
-            "type": "foo"
-        },
-    ]
-
-    # act
-    get_world_ids(config, filtered_cases)
-
-    # assert
     assert ('root', logging.WARNING, 'Case rejected. Missing Field Region') in caplog.record_tuples
 
 
 @mock.patch.object(OptimiseClient, "get_worlds")
 def test_get_world_ids_logs_a_console_error_and_returns_data_when_given_an_unknown_world_and_a_known_world_and_a_known_world(
         _mock_optimise_client, caplog):
-    # arrange
     config = config_helper.get_default_config()
 
-    filtered_cases = [QuestionnaireCaseModel(field_region = ""),
-                      QuestionnaireCaseModel(field_region = "Region 1")]    
+    filtered_cases = [QuestionnaireCaseModel(field_region=""),
+                      QuestionnaireCaseModel(field_region="Region 1")]
 
-    _mock_optimise_client.return_value = [
-        {
-            "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "identity": {
-                "reference": "Region 1"
-            },
-            "type": "foo"
-        },
-    ]
+    world_ids = {
+        "Region 1": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    }
 
-    # act
-    world_ids, new_filtered_cases = get_world_ids(config, filtered_cases)
+    cases_with_valid_world_ids = get_cases_with_valid_world_ids(filtered_cases, world_ids)
 
-    # assert
-    assert len(world_ids) == len(new_filtered_cases)
-    assert world_ids == ["3fa85f64-5717-4562-b3fc-2c963f66afa6"]
-    assert new_filtered_cases == [QuestionnaireCaseModel(field_region = "Region 1")]
+    assert len(cases_with_valid_world_ids) == 1
+    assert cases_with_valid_world_ids == [QuestionnaireCaseModel(field_region = "Region 1")]
     assert ('root', logging.WARNING, 'Case rejected. Missing Field Region') in caplog.record_tuples
 
 
@@ -685,28 +630,28 @@ def test_uacs_are_correctly_appended_to_case_data():
     }
 
     filtered_cases = [QuestionnaireCaseModel(
-        serial_number = "10030", 
-        telephone_number_1 = "", 
-        telephone_number_2 = "", 
-        appointment_telephone_number = "",
-        wave = "1", 
-        priority = "1", 
-        outcome_code = "310")]    
+        serial_number="10030",
+        telephone_number_1="",
+        telephone_number_2="",
+        appointment_telephone_number="",
+        wave="1",
+        priority="1",
+        outcome_code="310")]
 
     result = append_uacs_to_retained_case(filtered_cases, case_uacs)
     assert result == [QuestionnaireCaseModel(
-                serial_number = "10030", 
-                telephone_number_1 = "", 
-                telephone_number_2 = "", 
-                appointment_telephone_number = "",
-                wave = "1", 
-                priority = "1", 
-                outcome_code = "310",
-                uac_chunks = UacChunks(
-                    uac1 = "8176",
-                    uac2 = "4726",
-                    uac3 = "3993"
-                ))]  
+        serial_number="10030",
+        telephone_number_1="",
+        telephone_number_2="",
+        appointment_telephone_number="",
+        wave="1",
+        priority="1",
+        outcome_code="310",
+        uac_chunks=UacChunks(
+            uac1="8176",
+            uac2="4726",
+            uac3="3993"
+        ))]
 
 
 def test_uacs_with_blank_values_are_appended_to_case_data_when_case_id_not_found_in_bus():
@@ -724,30 +669,29 @@ def test_uacs_with_blank_values_are_appended_to_case_data_when_case_id_not_found
     }
 
     filtered_cases = [QuestionnaireCaseModel(
-        serial_number = "10030", 
-        telephone_number_1 = "", 
-        telephone_number_2 = "", 
-        appointment_telephone_number = "",
-        wave = "1", 
-        priority = "1", 
-        outcome_code = "310")]    
-
+        serial_number="10030",
+        telephone_number_1="",
+        telephone_number_2="",
+        appointment_telephone_number="",
+        wave="1",
+        priority="1",
+        outcome_code="310")]
 
     result = append_uacs_to_retained_case(filtered_cases, case_uacs)
     assert result == [QuestionnaireCaseModel(
-                serial_number = "10030", 
-                telephone_number_1 = "", 
-                telephone_number_2 = "", 
-                appointment_telephone_number = "",
-                wave = "1", 
-                priority = "1", 
-                outcome_code = "310",
-                uac_chunks = UacChunks(
-                    uac1 = "",
-                    uac2 = "",
-                    uac3 = ""
-                ))]   
-    
+        serial_number="10030",
+        telephone_number_1="",
+        telephone_number_2="",
+        appointment_telephone_number="",
+        wave="1",
+        priority="1",
+        outcome_code="310",
+        uac_chunks=UacChunks(
+            uac1="",
+            uac2="",
+            uac3=""
+        ))]
+
 
 def test_an_error_is_logged_when_the_case_id_is_not_found_in_bus(caplog):
     case_uacs = {
@@ -764,13 +708,13 @@ def test_an_error_is_logged_when_the_case_id_is_not_found_in_bus(caplog):
     }
 
     filtered_cases = [QuestionnaireCaseModel(
-        serial_number = "10030", 
-        telephone_number_1 = "", 
-        telephone_number_2 = "", 
-        appointment_telephone_number = "",
-        wave = "1", 
-        priority = "1", 
-        outcome_code = "310")]    
+        serial_number="10030",
+        telephone_number_1="",
+        telephone_number_2="",
+        appointment_telephone_number="",
+        wave="1",
+        priority="1",
+        outcome_code="310")]
 
-    result = append_uacs_to_retained_case(filtered_cases, case_uacs)
+    append_uacs_to_retained_case(filtered_cases, case_uacs)
     assert ('root', logging.WARNING, 'Serial number 10030 not found in BUS') in caplog.record_tuples

--- a/tests/cloud_functions/test_create_questionnaire_case_tasks.py
+++ b/tests/cloud_functions/test_create_questionnaire_case_tasks.py
@@ -365,7 +365,9 @@ def test_validate_request_when_missing_fields():
 @mock.patch("client.bus.BusClient.get_uacs_by_case_id")
 @mock.patch("cloud_functions.create_questionnaire_case_tasks.filter_cases")
 @mock.patch("cloud_functions.create_questionnaire_case_tasks.run_async_tasks")
+@mock.patch("cloud_functions.create_questionnaire_case_tasks.get_cases_with_valid_world_ids")
 def test_create_case_tasks_for_questionnaire(
+        mock_get_cases_with_valid_world_ids,
         mock_run_async_tasks,
         mock_filter_cases,
         mock_get_uacs_by_case_id,
@@ -396,15 +398,15 @@ def test_create_case_tasks_for_questionnaire(
         serial_number="10010",
         uac_chunks=UacChunks(uac1="8176", uac2="4726", uac3="3991"))]
 
-    mock_get_world_ids.return_value = "1", [QuestionnaireCaseModel(serial_number="10010")]
+    mock_get_world_ids.return_value = "1"
+    mock_get_cases_with_valid_world_ids.return_value = [QuestionnaireCaseModel(serial_number="10010")]
+
     # act
     result = create_questionnaire_case_tasks(mock_request, config)
 
     # assert
     mock_get_questionnaire_case_model_list.assert_called_with("LMS2101_AA1", config)
-    mock_get_world_ids.assert_called_with(config, [QuestionnaireCaseModel(
-        serial_number="10010",
-        uac_chunks=UacChunks(uac1="8176", uac2="4726", uac3="3991"))])
+    mock_get_world_ids.assert_called_with(config)
     mock_filter_cases.assert_called_with([
         QuestionnaireCaseModel(serial_number="10010"),
         QuestionnaireCaseModel(serial_number="10012")])


### PR DESCRIPTION
Currently the function returns two values. This makes testing harder as two values need to be unpacked and one function is responsible for two tasks. Split out - more logical and easier to test

Reviewed-by: James
Refs: N/A