### PR TITLE
fix: Skip bad references when loading jobs

### DIFF
--- a/models/totalmobile/totalmobile_get_jobs_response_model.py
+++ b/models/totalmobile/totalmobile_get_jobs_response_model.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, List, Type, TypeVar
 
+from app.exceptions.custom_exceptions import BadReferenceError
 from client.optimise import GetJobsResponse
 from models.totalmobile.totalmobile_reference_model import TotalmobileReferenceModel
 
@@ -26,10 +27,18 @@ class TotalmobileGetJobsResponseModel:
             visit_complete = job["visitComplete"]
             job_reference = job["identity"]["reference"]
 
-            reference_model = TotalmobileReferenceModel.from_reference(job_reference)
-
-            job_instance = Job(job_reference, reference_model.case_id, visit_complete)
-            questionnaire_jobs[reference_model.questionnaire_name].append(job_instance)
+            try:
+                reference_model = TotalmobileReferenceModel.from_reference(
+                    job_reference
+                )
+                job_instance = Job(
+                    job_reference, reference_model.case_id, visit_complete
+                )
+                questionnaire_jobs[reference_model.questionnaire_name].append(
+                    job_instance
+                )
+            except BadReferenceError:
+                pass  # The model logs a warning so we just carry on
 
         return cls(dict(questionnaire_jobs))
 

--- a/services/delete_totalmobile_jobs_service.py
+++ b/services/delete_totalmobile_jobs_service.py
@@ -29,7 +29,7 @@ class DeleteTotalmobileJobsService:
         self._delete_reason = "completed in blaise"
 
     def delete_totalmobile_jobs_completed_in_blaise(self) -> None:
-        world_ids = self.get_world_ids()
+        world_ids = self._get_world_ids()
         for world_id in world_ids:
             for (
                 questionnaire_name,
@@ -81,7 +81,7 @@ class DeleteTotalmobileJobsService:
             )
             return {}
 
-    def get_world_ids(self):
+    def _get_world_ids(self):
         world_model = self._totalmobile_service.get_world_model()
         return [
             world.id


### PR DESCRIPTION
- refactor: Rename method
- fix: Skip bad references when loading jobs
