### PR TITLE
BLAIS5-3625: Get TLA from the Q Name instead of hardcoding

### DIFF
--- a/models/totalmobile/totalmobile_outgoing_create_job_payload_model.py
+++ b/models/totalmobile/totalmobile_outgoing_create_job_payload_model.py
@@ -166,6 +166,8 @@ class TotalMobileOutgoingCreateJobPayloadModel:
         questionnaire_case: BlaiseCaseInformationModel,
         uac_chunks: Optional[UacChunks],
     ) -> T:
+        tla = questionnaire_name[0:3] if len(questionnaire_name) >= 3 else questionnaire_name
+        
         total_mobile_case = cls(
             identity=Reference(
                 reference=cls.create_job_reference(
@@ -177,8 +179,8 @@ class TotalMobileOutgoingCreateJobPayloadModel:
             ),
             origin="ONS",
             duration=15,
-            workType="LMS",
-            skills=[Skill(identity=Reference(reference="LMS"))],
+            workType=tla,
+            skills=[Skill(identity=Reference(reference=tla))],
             dueDate=DueDate(end=questionnaire_case.wave_com_dte),
             location=AddressDetails(
                 reference=cls.set_location_reference(questionnaire_case),
@@ -208,7 +210,7 @@ class TotalMobileOutgoingCreateJobPayloadModel:
                 AdditionalProperty(
                     name="surveyName", value=questionnaire_case.data_model_name
                 ),
-                AdditionalProperty(name="tla", value="LMS"),
+                AdditionalProperty(name="tla", value=tla),
                 AdditionalProperty(name="wave", value=str(questionnaire_case.wave)),
                 AdditionalProperty(name="priority", value=questionnaire_case.priority),
                 AdditionalProperty(


### PR DESCRIPTION
### 🛠 Changes being made
Here give examples of the changes you've made in this pull request. Include an itemized list if you can. It'll help the reviewer

* Replaced hard coded "LMS" with first three letters of the questionnaire name
https://jira.ons.gov.uk/browse/BLAIS5-3625


### ✨ What's the context?
What's the context for the changes? Are there any

* [BLAIS5-3925] Refactor BTS to get the questionnaire TLA from the questionnaire name instead of hardcoding
https://jira.ons.gov.uk/browse/BLAIS5-3925

### 🧠 Rationale behind the change
Why did you choose to make these changes? Were there any trade-offs you had to consider? 

* Replaced hard coded "LMS" with first three letters of the questionnaire name


### 🧪 Test plan
How do you know the changes are safe to ship to production?

* All TDD and BDD tests are passing; it's a minor change.


### 📸 Screenshots (optional)
If you made UI changes, what are the before an afters?

* TDD tests pass as seen below:
<img width="1081" alt="image" src="https://github.com/ONSdigital/blaise-totalmobile-services/assets/171134774/4ecca9f8-9430-445b-a151-442297664a35">


### 🏎 Quality check
- [x] Are your changes following SOLID principles?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
- [x] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?